### PR TITLE
Update sprint 2.2

### DIFF
--- a/sprints/sprint2_1.md
+++ b/sprints/sprint2_1.md
@@ -31,7 +31,6 @@ This sprint encompasses the following usages:
     - Each `IfcTunnel` may only be decomposed by `IfcTunnel` or `IfcTunnelPart`.
     - There shall be at least one `IfcTunnel` in the file with non-empty `Name`.
 - Linear Composition
-    - in progress: https://github.com/bSI-InfraRoom/IFC-Specification/issues/523
     - There shall be one `IfcAlignment` in the file with non-empty `Name`.
 - [Alignment Layout](https://bsi-infraroom.github.io/IFC-Documentation-Tunnel/4_4_0_0/general/HTML/link/alignment-layout.htm)
     - There shall be at least one `LINE`, at least one `CIRCULARARC` and at least one `CLOTHOID` segments nested in the horizontal layout (see `IfcAlignmentHorizontalSegment.PredefinedType`).

--- a/sprints/sprint2_2.md
+++ b/sprints/sprint2_2.md
@@ -42,6 +42,10 @@ This sprint encompasses the following usages:
         - representation is `IfcCompositeCurve` (the same instance used as `IfcGradientCurve.BaseCurve` or `IfcSegmentedReferenceCurve.BaseCurve.BaseCurve` above),
 - [Product Linear Placement](https://bsi-infraroom.github.io/IFC-Documentation-Tunnel/4_4_0_0/general/HTML/link/product-linear-placement.htm)
     - All `IfcReferent` instances shall be linearly placed according to the [Product Linear Placement](https://bsi-infraroom.github.io/IFC-Documentation-Tunnel/4_4_0_0/general/HTML/link/product-linear-placement.htm) concept template (i.e. `IfcReferent.ObjectPlacement.PlacementRelTo` shall point to `IfcReferent.PositionedRelativeTo.RelatingPositioningElement.ObjectPlacement`).
+- [Element Nesting](https://bsi-infraroom.github.io/IFC-Documentation-Tunnel/4_4_0_0/general/HTML/link/element-nesting.htm)
+    - All `IfcReferent` instances shall be linearly placed according to the [Product Linear Placement](https://bsi-infraroom.github.io/IFC-Documentation-Tunnel/4_4_0_0/general/HTML/link/product-linear-placement.htm) concept template:
+        - `IfcReferent.ObjectPlacement` shall be `IfcLinearPlacement`.
+        - `IfcReferent.ObjectPlacement.PlacementRelTo` shall point to `IfcReferent.Nests.RelatingObject.ObjectPlacement`.
 - [Linear Composition](https://github.com/bSI-InfraRoom/IFC-Specification/pull/557)
     - All `IfcAlignment` instances shall be aggregated in `IfcProject`. It shall use its own `IfcRelAggregates` instance and not share it with the [Spatial Decomposition](https://bsi-infraroom.github.io/IFC-Documentation-Tunnel/4_4_0_0/general/HTML/link/spatial-decomposition.htm) usage from Sprint 1.2.
 

--- a/sprints/sprint2_2.md
+++ b/sprints/sprint2_2.md
@@ -40,8 +40,6 @@ This sprint encompasses the following usages:
         - `RepresentationIdentifier = 'Axis'`
         - `RepresentationType = 'Curve2D'`
         - representation is `IfcCompositeCurve` (the same instance used as `IfcGradientCurve.BaseCurve` or `IfcSegmentedReferenceCurve.BaseCurve.BaseCurve` above),
-- [Product Linear Placement](https://bsi-infraroom.github.io/IFC-Documentation-Tunnel/4_4_0_0/general/HTML/link/product-linear-placement.htm)
-    - All `IfcReferent` instances shall be linearly placed according to the [Product Linear Placement](https://bsi-infraroom.github.io/IFC-Documentation-Tunnel/4_4_0_0/general/HTML/link/product-linear-placement.htm) concept template (i.e. `IfcReferent.ObjectPlacement.PlacementRelTo` shall point to `IfcReferent.PositionedRelativeTo.RelatingPositioningElement.ObjectPlacement`).
 - [Element Nesting](https://bsi-infraroom.github.io/IFC-Documentation-Tunnel/4_4_0_0/general/HTML/link/element-nesting.htm)
     - All `IfcReferent` instances shall be linearly placed according to the [Product Linear Placement](https://bsi-infraroom.github.io/IFC-Documentation-Tunnel/4_4_0_0/general/HTML/link/product-linear-placement.htm) concept template:
         - `IfcReferent.ObjectPlacement` shall be `IfcLinearPlacement`.

--- a/sprints/sprint2_3.md
+++ b/sprints/sprint2_3.md
@@ -1,4 +1,4 @@
-# Sprint 2.1
+# Sprint 2.3
 
 This sprint implements and tests project structure specific usages.
 
@@ -25,6 +25,10 @@ This sprint assumes you completed the following sprints:
 
 This sprint encompasses the following usages:
 
+- Linear Composition
+    - in progress: https://github.com/bSI-InfraRoom/IFC-Specification/issues/523
+- [Product Linear Placement](https://bsi-infraroom.github.io/IFC-Documentation-Tunnel/4_4_0_0/general/HTML/link/product-linear-placement.htm)
+    - All `IfcElement` instances which are linearly placed, shall be placed according to the [Product Linear Placement](https://bsi-infraroom.github.io/IFC-Documentation-Tunnel/4_4_0_0/general/HTML/link/product-linear-placement.htm) concept template, i.e. `IfcReferent.ObjectPlacement.PlacementRelTo` shall point to `IfcReferent.PositionedRelativeTo.RelatingPositioningElement.ObjectPlacement`.
 - [Body Tesselation Geometry](https://bsi-infraroom.github.io/IFC-Documentation-Tunnel/4_4_0_0/general/HTML/link/body-tessellation-geometry.htm)
     - on the example of `IfcGeoScienceModel` (other `IfcProduct` allowed)
 - [Body Brep Geometry](https://bsi-infraroom.github.io/IFC-Documentation-Tunnel/4_4_0_0/general/HTML/link/body-brep-geometry.htm)


### PR DESCRIPTION
## Miscellaneous

- updated `Element Nesting` usage for `IfcReferent` for Sprint 2.2
- moved usages not covered in Sprint 2.1 and 2.2 to Sprint 2.3 (still to be discussed, though, but in another PR)
